### PR TITLE
Fixed #4

### DIFF
--- a/babelfish/tag_template.html
+++ b/babelfish/tag_template.html
@@ -3,12 +3,12 @@
 <b>Filename:</b> [filename]<br>
 <b>Classifier:</b> [coefset] 	<br>
 <br>
-<FONT style="BACKGROUND-COLOR: gold">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_0] <br> <!-- BLUE -->
-<FONT style="BACKGROUND-COLOR: #00ff00">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_1] <br> <!-- GREEN -->
-<FONT style="BACKGROUND-COLOR: #A10F8E">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_2] <br> <!-- PURPLE -->
-<FONT style="BACKGROUND-COLOR: cyan">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_3] <br> <!-- GOLD -->
-<FONT style="BACKGROUND-COLOR: #003B7E">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_4] <br> <!-- BLUE -->
-<FONT style="BACKGROUND-COLOR: black">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_5] <br> <!-- BLACK -->
+<FONT style="BACKGROUND-COLOR: #5ca6d4">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_0] <br> <!-- BLUE -->
+<FONT style="BACKGROUND-COLOR: #ac7ac2">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_1] <br> <!-- PURPLE -->
+<FONT style="BACKGROUND-COLOR: #3cba9f">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_2] <br> <!-- GREEN -->
+<FONT style="BACKGROUND-COLOR: #e8c3b9">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_3] <br> <!-- PINK -->
+<FONT style="BACKGROUND-COLOR: #c45850">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_4] <br> <!-- RED -->
+<FONT style="BACKGROUND-COLOR: #613763">&nbsp&nbsp&nbsp&nbsp </FONT> 	&nbsp= [cl_5] <br> <!-- PURPLE -->
 </HTML>
 <br>
 <b>Notes:</b><br>

--- a/templates/report.html
+++ b/templates/report.html
@@ -102,6 +102,9 @@
               <div class="x_content pre-scrollable" id="toNewWindow" style="display:none">
                 {{ report }}
               </div>
+              <div class="x_content pre-scrollable" id="toNewWindow2">
+                {{ report }}
+              </div>
             </div>
           </div>
         </div>
@@ -156,6 +159,16 @@
 
                             $(function() {  
                                 $("a#print").click(nWin);
+                                
+                                $( "#toNewWindow2" ).contents().filter(function() {
+                                  return this.nodeType === 3;
+                                })
+                                  .wrap( "<p></p>" )
+                                  .end()
+                                  .filter( "br" )
+                                  .remove();
+                                $('#toNewWindow2').contents().hide(); //hide all nodes directly under the body
+                                $('#toNewWindow2').find("font").show();
                             });
 
                          </script>


### PR DESCRIPTION
Replaced scrollable window that contains babelfish's tagged report.  Now it only displays the highlighted text in the field, and the highlights now match the colors on the line and bar graphs.  The "Details" link still opens up the full tagged report unabridged. 